### PR TITLE
Guard for when build.commitId is null

### DIFF
--- a/dcc-dev-ui/src/app/portal-controls/portal-controls.component.ts
+++ b/dcc-dev-ui/src/app/portal-controls/portal-controls.component.ts
@@ -55,7 +55,7 @@ export class PortalControls implements OnInit {
     ) {}
 
   ngOnInit () {
-    this.build && this.updateBuildCommitData();
+    this.build && this.build.commitId && this.updateBuildCommitData();
     this.pr && this.updatePRHeadData();
 
     if (this.portal) {


### PR DESCRIPTION
Do not try to update commit data when build.commitId is null